### PR TITLE
Increase open file limit and monitor main port

### DIFF
--- a/jobs/memcache_hazelcast/monit
+++ b/jobs/memcache_hazelcast/monit
@@ -3,4 +3,5 @@ check process memcache_hazelcast
   start program "/var/vcap/jobs/memcache_hazelcast/bin/memcache_hazelcast start" with timeout <%= p('memcache_hazelcast.startup_timeout')+10 %> seconds
   stop program "/var/vcap/jobs/memcache_hazelcast/bin/memcache_hazelcast stop"
   if failed port <%= p('memcache_hazelcast.host.port') %> for 2 cycles then restart
+  if failed port <%= p('memcache_hazelcast.memcache.port') %> for 2 cycles then restart
   group vcap

--- a/jobs/memcache_hazelcast/spec
+++ b/jobs/memcache_hazelcast/spec
@@ -19,6 +19,9 @@ properties:
   memcache_hazelcast.heap_size:
     description: The amount of Heap the cache should be configured with.
     default: 1G
+  memcache_hazelcast.open_file_limit:
+    description: The ulimit for the maximum number of files/connections that are allowed
+    default: 16384
   memcache_hazelcast.java_opts:
     description: Any Java opts we wish to apply beyond Xmx and TMP_DIR
     default:  -Xms32m -XX:+UseG1GC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -Duser.timezone=UTC -Djava.net.preferIPv4Stack=true -Xss256k

--- a/jobs/memcache_hazelcast/templates/memcache_hazelcast.erb
+++ b/jobs/memcache_hazelcast/templates/memcache_hazelcast.erb
@@ -29,7 +29,9 @@ case $1 in
 
     sysctl vm.swappiness=5
 
-run_java <%= p('memcache_hazelcast.startup_timeout') %> $PIDFILE 'chpst -u vcap:vcap $JAVA_HOME/bin/java -server -Djava.io.tmpdir=$TMP_DIR -Xmx<%= p('memcache_hazelcast.heap_size') %> \
+    ulimit -n <%= p('memcache_hazelcast.open_file_limit') %>
+
+    run_java <%= p('memcache_hazelcast.startup_timeout') %> $PIDFILE 'chpst -u vcap:vcap $JAVA_HOME/bin/java -server -Djava.io.tmpdir=$TMP_DIR -Xmx<%= p('memcache_hazelcast.heap_size') %> \
 -XX:OnOutOfMemoryError="kill -9 %p" <%= p('memcache_hazelcast.java_opts') %> \
 <%= properties.memcache_hazelcast.debug ? " -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=#{properties.memcache_hazelcast.debug}" : '' %> \
 -XX:+PrintGC -XX:+PrintGCDateStamps -Dhazelcast.health.monitoring.level=NOISY -Dhazelcast.health.monitoring.delay.seconds=60 \


### PR DESCRIPTION
We've had problems where memcache will stop listening on its port
(11211 by default) but the hazelcast server seems to still be healthy. We typically
see an IOException with the message "Too many open files".

Now monit will restart memcache if it stops listening on its port. Also,
there is now a BOSH property (memcache_hazelcast.open_file_limit) which
allows the operator to specify the maximum number of open
files/connections.